### PR TITLE
Update slevomat/coding-standard and remove unavailable sniff

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "MessageCloud Coding Standard",
     "require": {
         "squizlabs/php_codesniffer": "^3.0",
-        "slevomat/coding-standard": "dev-master#63a8186b129ee96d1277e68c80cf87c8cdb356d1",
+        "slevomat/coding-standard": "^5.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "MessageCloud Coding Standard",
     "require": {
         "squizlabs/php_codesniffer": "^3.0",
-        "slevomat/coding-standard": "^4.6",
+        "slevomat/coding-standard": "^5.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "MessageCloud Coding Standard",
     "require": {
         "squizlabs/php_codesniffer": "^3.0",
-        "slevomat/coding-standard": "^5.0",
+        "slevomat/coding-standard": "dev-master#63a8186b129ee96d1277e68c80cf87c8cdb356d1",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4"
     },
     "require-dev": {

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -231,7 +231,4 @@
 
     <!-- Forbid useless alias for classes, constants and functions -->
     <rule ref="SlevomatCodingStandard.Namespaces.UselessAlias"/>
-
-    <!-- Require /* @var type $foo */ and similar simple inline annotations to be replaced by assert() -->
-    <rule ref="SlevomatCodingStandard.PHP.RequireExplicitAssertion"/>
 </ruleset>


### PR DESCRIPTION
Unfortunately `SlevomatCodingStandard.PHP.RequireExplicitAssertion` is not yet available in a tagged release of `slevomat/coding-standard` so I've had to remove it from the ruleset. When it becomes available I'll add it back to the ruleset and tag a new release. _Technically_ by removing this rule I should bump the version to 4.0.0 but I'll be cheeky and just make it 3.0.1.