### PR TITLE
Fix - Composer v2 not supported with phpcodesniffer-composer-installer. Removing for now.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,7 @@
     "description": "MessageCloud Coding Standard",
     "require": {
         "squizlabs/php_codesniffer": "^3.0",
-        "slevomat/coding-standard": "^6.0",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0"
+        "slevomat/coding-standard": "^6.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master"

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="MessageCloud Coding Standard">
+    <config name="installed_paths" value="vendor/slevomat/coding-standard"/>
     <description>MessageCloud PHP Coding Standard. Essentially PSR2 with some modifications.</description>
 
     <arg name="colors"/>


### PR DESCRIPTION
Phpcs is causing builds to fail in gravity and cp7 because slevomat isn't being included because the phpcodesniffer composer installer isn't working with composer v2.

Just need to remove this plugin and reference the slevomat with a direct path for now. It's how they recommend doing it anyway. https://github.com/slevomat/coding-standard#how-to-run-the-sniffs

nb. phpcodesniffer-composer-installer hasn't been updated in 8 months so don't fancy waiting around until they support composer v2.